### PR TITLE
add support for python3

### DIFF
--- a/base32hex.py
+++ b/base32hex.py
@@ -101,7 +101,7 @@ def decode(src, str_map):
         if src_len >= 2:
             dst[0] = (dbuf[0] << 3) | (dbuf[1] >> 2)
 
-        dst = map(lambda x: x & 0xff, dst)
+        dst = list(map(lambda x: x & 0xff, dst))
 
         if src_len == 2:
             dst = dst[:1]
@@ -117,7 +117,7 @@ def decode(src, str_map):
         result.extend(dst)
         src = src[8:]
 
-    return ''.join(map(chr, result))
+    return result
 
 
 def b32encode(src):


### PR DESCRIPTION
When testing this using Python 3.5 it failed.

Relevant Error:

```
Traceback (most recent call last):
  File "test_base32hex.py", line 12, in test_copy_string_from_golang
    x = base32hex.b32decode('9m4e2mr0ui3e8a215n4g')
  File "base32hex.py", line 131, in b32decode
    return decode(src, encodeHex)
  File "base32hex.py", line 115, in decode
    dst = dst[:5]
TypeError: 'map' object is not subscriptable
```