### PR TITLE
fix: str encode error "TypeError: object of type 'map' has no len()"

### DIFF
--- a/base32hex.py
+++ b/base32hex.py
@@ -122,7 +122,7 @@ def decode(src, str_map):
 
 def b32encode(src):
     if type(src) == str:
-        return encode(map(ord, src), encodeHex)
+        return encode(list(map(ord, src)), encodeHex)
     else:
         return encode(src, encodeHex)
 

--- a/test_base32hex.py
+++ b/test_base32hex.py
@@ -8,6 +8,10 @@ class TestBase32Hex(unittest.TestCase):
                                  0x86, 0xe4, 0x28, 0x41, 0x2d, 0xc9])
         self.assertEqual('9m4e2mr0ui3e8a215n4g===='.upper(), x)
 
+    def test_string_encode(self):
+        x = base32hex.b32encode('base32hex_encoder')
+        self.assertEqual('C9GN6P9J69K6AU2VCLN66RR4CLP0===='.upper(), x)
+
     def test_copy_string_from_golang(self):
         x = base32hex.b32decode('9m4e2mr0ui3e8a215n4g')
         self.assertEqual(x, [0x4d, 0x88, 0xe1, 0x5b, 0x60, 0xf4,


### PR DESCRIPTION
Thanks for making a useful library.

There was an error when encoding the string, so I made a fix.
I've also added a unit case, so please merge it if it's okay.

A string encoding error.
```
$ python3 test_base32hex.py
..E
======================================================================
ERROR: test_string_encode (__main__.TestBase32Hex)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_base32hex.py", line 12, in test_string_encode
    x = base32hex.b32encode('base32hex_encoder')
  File "/home/hasegawa/base32hex/base32hex.py", line 126, in b32encode
    return encode(map(ord, src), encodeHex)
  File "/home/hasegawa/base32hex/base32hex.py", line 21, in encode
    if len(src) == 0:
TypeError: object of type 'map' has no len()

----------------------------------------------------------------------
Ran 3 tests in 0.001s

FAILED (errors=1)
```

Test results after the patch was applied.
```
$ python3 test_base32hex.py
...
----------------------------------------------------------------------
Ran 3 tests in 0.000s

OK
```